### PR TITLE
feat: basic lineup interface

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LineUp Manager</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="app">
+    <aside class="sidebar">
+      <h1 class="logo">LineUp Manager</h1>
+      <nav class="menu">
+        <a href="#field" class="menu-item">Campi di gioco</a>
+        <a href="#players" class="menu-item">Gerarchia giocatori</a>
+      </nav>
+    </aside>
+    <main class="content">
+      <section id="field" class="field-section">
+        <h2>Campi di gioco</h2>
+        <div class="field">
+          <div class="player gk">GK</div>
+          <div class="player lb">LB</div>
+          <div class="player cb1">CB</div>
+          <div class="player cb2">CB</div>
+          <div class="player rb">RB</div>
+          <div class="player cm1">CM</div>
+          <div class="player cm2">CM</div>
+          <div class="player cm3">CM</div>
+          <div class="player lw">LW</div>
+          <div class="player st">ST</div>
+          <div class="player rw">RW</div>
+        </div>
+      </section>
+      <section id="players" class="players-section">
+        <h2>Gerarchia giocatori</h2>
+        <p>Seleziona un giocatore per modificarne la posizione.</p>
+      </section>
+    </main>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,4 @@
+// Placeholder for interactivity
+// Future enhancements could include drag-and-drop to rearrange players,
+// dynamic formation changes, and data persistence.
+console.log('LineUp Manager loaded');

--- a/style.css
+++ b/style.css
@@ -1,0 +1,100 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  font-family: Arial, sans-serif;
+}
+
+body {
+  background-color: #1e1e2f;
+  color: #fff;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 240px;
+  background-color: #111827;
+  padding: 1rem;
+}
+
+.logo {
+  font-size: 1.25rem;
+  margin-bottom: 2rem;
+}
+
+.menu-item {
+  display: block;
+  color: #9ca3af;
+  text-decoration: none;
+  padding: 0.5rem 0;
+}
+
+.menu-item:hover {
+  color: #fff;
+}
+
+.content {
+  flex: 1;
+  padding: 1rem;
+}
+
+.field-section {
+  margin-bottom: 2rem;
+}
+
+.field {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  height: 400px;
+  margin: 1rem auto;
+  background: repeating-linear-gradient(
+    to bottom,
+    #066a43,
+    #066a43 40px,
+    #058240 40px,
+    #058240 80px
+  );
+  border: 2px solid #fff;
+  border-radius: 4px;
+}
+
+.player {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background-color: rgba(0,0,0,0.6);
+  border: 2px solid #fff;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+/* Positions for a 4-3-3 formation */
+.gk { left: calc(50% - 25px); bottom: 20px; background-color: #fbbf24; }
+.lb { left: 10%; bottom: 100px; }
+.cb1 { left: 35%; bottom: 120px; }
+.cb2 { left: 65%; bottom: 120px; }
+.rb { right: 10%; bottom: 100px; }
+.cm1 { left: 30%; bottom: 220px; }
+.cm2 { left: calc(50% - 25px); bottom: 240px; }
+.cm3 { left: 70%; bottom: 220px; }
+.lw { left: 15%; bottom: 320px; }
+.st { left: calc(50% - 25px); bottom: 340px; }
+.rw { right: 15%; bottom: 320px; }
+
+.players-section {
+  background-color: #111827;
+  padding: 1rem;
+  border-radius: 4px;
+}
+
+.players-section h2 {
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add a static LineUp Manager page with sidebar navigation
- style a pitch and players in a 4-3-3 formation
- scaffold JS entry point for future interactivity

## Testing
- `npm test` *(fails: missing package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b81b39ffe4832f9bbd6bf343c23716